### PR TITLE
fixes broken connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ BREAKING CHANGES:
 * Resource `auth0_global_client` has been deleted
 * `auth0_connection.options` is now a required field. It can be empty (but set to `options {}`). This is due to a limitation in nested defaults from Terraform (if that value is not set, it's much harder to catch drifts)
 
+BUG FIXES:
+* Empty non_persistent_attrs no longer breaks Auth0 connection webui (however it will still break if it's set to anything, this is a bug on Auth0 side)
+
 ## 0.21.1
 
 FIXES: 

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -698,6 +698,9 @@ func expandConnectionOptionsScopes(d ResourceData, s scoper) {
 }
 
 func castToListOfStrings(interfaces []interface{}) *[]string {
+	if len(interfaces) == 0 {
+		return nil
+	}
 	var strings []string
 	for _, v := range interfaces {
 		strings = append(strings, v.(string))


### PR DESCRIPTION
Fixes https://github.com/alexkappa/terraform-provider-auth0/issues/382 (kind of)

Long story short: even though the `non_persistent_attrs` are supported by the api documentation, their usage completely breaks the Auth0 webui.  

The fix will resolve the issue in case the attribute is not set at all, but wont' resolve the root cause (It's up to Auth0)

Sadly, it looks like connections which have been afflicted by the bug will either have to be recreated, or their usage of Webui will be limited. It's not clear if affected connections suffer anywhere else. 