### PR TITLE
Datadog fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,13 @@ jobs:
     - name: Build
       run: make build
 
+    - name: Clean testing env
+      run: make sweep
+      env:
+        AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+        AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+        AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+
     - name: Test
       run: make testacc OPTS=-coverprofile=c.out
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ ENHANCEMENTS:
 * Introduced parallelism to tests
 * Custom domain is ignored now if the testing account is not premium
 * Created a new make target `make install-local`. To use it run `make install-local version=1.0.0`, and it will build the provider and place it local terraform sdk plugin folder. It can be used with `source  = "local/alekc/auth0"` in your provider source attribute.
-* Added provider's [debug capability](https://www.terraform.io/docs/extend/debugging.html#enabling-debugging-in-a-provider). It can be invoked with 
+* Added provider's [debug capability](https://www.terraform.io/docs/extend/debugging.html#enabling-debugging-in-a-provider). It can be invoked with
+* Added validation for datadog log stream region (capital case was throwing an error on Auth0 side)
 
 BREAKING CHANGES:
 * All addons from the `auth0_client` has been dropped, except for those present in the webui (Saml2 and WS-FED).

--- a/auth0/resource_auth0_log_stream.go
+++ b/auth0/resource_auth0_log_stream.go
@@ -137,9 +137,13 @@ func newLogStream() *schema.Resource {
 						},
 
 						"datadog_region": {
-							Type:         schema.TypeString,
-							Sensitive:    true,
-							Optional:     true,
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Optional:  true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"eu",
+								"us",
+							}, false),
 							RequiredWith: []string{"sink.0.datadog_api_key"},
 						},
 						"datadog_api_key": {

--- a/auth0/resource_auth0_log_stream_test.go
+++ b/auth0/resource_auth0_log_stream_test.go
@@ -2,6 +2,7 @@ package auth0
 
 import (
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -242,16 +243,30 @@ func TestAccLogStreamDatadog(t *testing.T) {
 		ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				// this should fail due to capital case (Auth0 is very picky)
 				Config: random.Template(`
 resource "auth0_log_stream" "my_log_stream" {
 	name = "Acceptance-Test-LogStream-datadog-{{.random}}"
 	type = "datadog"
 	sink {
-	  datadog_region = "us"
-	  datadog_api_key = "121233123455"
+	  datadog_region = "EU"
+	  datadog_api_key = "1212331234556667"
 	}
 }
 `, rand),
+				ExpectError: regexp.MustCompile("expected sink.0.datadog_region to be one of"),
+			},
+			{
+				Config: random.Template(`
+			resource "auth0_log_stream" "my_log_stream" {
+				name = "Acceptance-Test-LogStream-datadog-{{.random}}"
+				type = "datadog"
+				sink {
+				  datadog_region = "us"
+				  datadog_api_key = "121233123455"
+				}
+			}
+			`, rand),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-datadog-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "datadog"),
@@ -261,15 +276,15 @@ resource "auth0_log_stream" "my_log_stream" {
 			},
 			{
 				Config: random.Template(`
-resource "auth0_log_stream" "my_log_stream" {
-	name = "Acceptance-Test-LogStream-datadog-{{.random}}"
-	type = "datadog"
-	sink {
-	  datadog_region = "eu"
-	  datadog_api_key = "121233123455"
-	}
-}
-`, rand),
+			resource "auth0_log_stream" "my_log_stream" {
+				name = "Acceptance-Test-LogStream-datadog-{{.random}}"
+				type = "datadog"
+				sink {
+				  datadog_region = "eu"
+				  datadog_api_key = "121233123455"
+				}
+			}
+			`, rand),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-datadog-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "datadog"),
@@ -279,15 +294,15 @@ resource "auth0_log_stream" "my_log_stream" {
 			},
 			{
 				Config: random.Template(`
-resource "auth0_log_stream" "my_log_stream" {
-	name = "Acceptance-Test-LogStream-datadog-{{.random}}"
-	type = "datadog"
-	sink {
-	  datadog_region = "eu"
-	  datadog_api_key = "1212331234556667"
-	}
-}
-`, rand),
+			resource "auth0_log_stream" "my_log_stream" {
+				name = "Acceptance-Test-LogStream-datadog-{{.random}}"
+				type = "datadog"
+				sink {
+				  datadog_region = "eu"
+				  datadog_api_key = "1212331234556667"
+				}
+			}
+			`, rand),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					random.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "name", "Acceptance-Test-LogStream-datadog-{{.random}}", rand),
 					resource.TestCheckResourceAttr("auth0_log_stream.my_log_stream", "type", "datadog"),


### PR DESCRIPTION
Fixes https://github.com/alexkappa/terraform-provider-auth0/issues/444

Auth0 is case sensitive towards `datadogRegion` property. If a capitalcase (ie. US) is used, api will return an error

```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "Payload validation error: 'Data does not match any schemas from 'oneOf''.",
  "errorCode": "invalid_body"
}
```

As consequence, a validation has been added to the tf resource. 