### PR TITLE
feat: added custom timeout for the auth0_action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+resource/auth0_action:
+  - '**/*action.go'
+  - '**/*action_test.go'
+  -
 resource/auth0_client:
   - '**/*client.go'
   - '**/*client_test.go'
@@ -17,6 +21,10 @@ resource/auth0_custom_domain:
 resource/auth0_email:
   - '**/*email.go'
   - '**/*email_test.go'
+
+resource/auth0_flow:
+  - '**/*flow.go'
+  - '**/*flow_test.go'
 
 resource/auth0_email_template:
   - '**/*email_template.go'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3 (Unreleased)
+IMPROVEMENTS:
+* Added custom timeout and waiting logic for auth0_action. [#30](https://github.com/alekc/terraform-provider-auth0/issues/30)
+
 ## 1.1.2
 FIXES:
 * logout property of samlp addon is not serialized properly. [#28](https://github.com/alekc/terraform-provider-auth0/issues/28)

--- a/auth0/resource_auth0_flow_test.go
+++ b/auth0/resource_auth0_flow_test.go
@@ -21,6 +21,10 @@ resource "auth0_action" "myaction" {
 	trigger {
 		id = "{{ .trigger_id }}"
 	}
+	dependency {
+		name    = "slack-notify"
+		version = "latest"
+	}
 	code = "exports.onExecutePostLogin = async (event, api) => {};"
 	deploy = true
 }
@@ -28,6 +32,68 @@ resource "auth0_action" "myaction2" {
 	name = "Acceptance Test - Action2 - {{.random}}"
 	trigger {
 		id = "{{ .trigger_id }}"
+	}
+	dependency {
+		name    = "slack-notify"
+		version = "0.1.7"
+	}
+# Dependency below won't be deployed due to the big size. 
+# See https://github.com/alekc/terraform-provider-auth0/issues/30
+#	dependency {
+#		name    = "bit-bin"
+#		version = "14.8.8"
+#	}
+	code = "exports.onExecutePostLogin = async (event, api) => {};"
+	deploy = true
+}
+resource "auth0_flow" "bind"{
+	trigger_id =  "{{ .trigger_id }}"
+	action {
+		display_name = "action1"
+		id = "${auth0_action.myaction.id}"
+	}
+	action {
+		display_name = "action2"
+		name = "${auth0_action.myaction2.name}"
+	}
+}
+`, data),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_flow.bind", "trigger_id", "post-login"),
+					resource.TestCheckResourceAttr("auth0_flow.bind", "action.#", "2"),
+					resource.TestCheckResourceAttr("auth0_flow.bind", "action.0.display_name", "action1"),
+					random.TestCheckResourceAttr("auth0_flow.bind", "action.0.name", "Acceptance Test - Action - {{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_flow.bind", "action.1.display_name", "action2"),
+					random.TestCheckResourceAttr("auth0_flow.bind", "action.1.name", "Acceptance Test - Action2 - {{.random}}", rand),
+				),
+			},
+			{
+				// language=HCL
+				Config: random.TemplateMap(`
+resource "auth0_action" "myaction" {
+	name = "Acceptance Test - Action - {{.random}}"
+	trigger {
+		id = "{{ .trigger_id }}"
+	}
+	dependency {
+		name    = "slack-notify"
+		version = "latest"
+	}
+	code = "exports.onExecutePostLogin = async (event, api) => {};"
+	deploy = true
+}
+resource "auth0_action" "myaction2" {
+	name = "Acceptance Test - Action2 - {{.random}}"
+	trigger {
+		id = "{{ .trigger_id }}"
+	}
+	dependency {
+		name    = "slack-notify"
+		version = "0.1.7"
+	}
+	dependency {
+		name    = "is-regex"
+		version = "1.1.4"
 	}
 	code = "exports.onExecutePostLogin = async (event, api) => {};"
 	deploy = true


### PR DESCRIPTION
Adds support for custom timeout. 
Actions will wait for the `status` of auth0_action to become built, and will return an error otherwise

Closes https://github.com/alekc/terraform-provider-auth0/issues/30

### Checklist

- [x] All added fields have proper documentation properties set up
- [x] All tests are passing
- [x] Any new code is covered by test coverage
- [x] Example files (in /example folder) have been amended